### PR TITLE
chore: update action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Deploy version discovery page
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4.1.0
       if: ${{ inputs.external_repository != '' }}
       with:
         personal_token: ${{ inputs.github-token }}


### PR DESCRIPTION
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: peaceiris/actions-gh-pages@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/